### PR TITLE
Update Fuseki Dockerfile to use archive URL

### DIFF
--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -20,7 +20,7 @@ COPY /docker_fuseki_config.ttl /fuseki
 WORKDIR /fuseki
 
 # Download and copy the tar.gz file into the container
-ADD https://dlcdn.apache.org/jena/binaries/apache-jena-fuseki-5.3.0.tar.gz /fuseki
+ADD https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-5.3.0.tar.gz /fuseki
 
 # Extract the tar.gz file
 RUN tar -xvzf apache-jena-fuseki-5.3.0.tar.gz


### PR DESCRIPTION
This pull request updates the source URL used to download Apache Jena Fuseki in the Docker build process to ensure more reliable and stable builds.

Dockerfile update:

* Changed the `ADD` command in `fuseki/Dockerfile` to fetch Apache Jena Fuseki from the official Apache archive site instead of the primary download CDN, which can help with long-term availability and reproducibility.